### PR TITLE
Fix typo in recursive directory comment

### DIFF
--- a/ImageCrawler/Program.cs
+++ b/ImageCrawler/Program.cs
@@ -68,7 +68,7 @@ namespace ImageCrawler
 
                 foreach (System.IO.DirectoryInfo dirInfo in subDirs)
                 {
-                    // Resursive call for each subdirectory.
+                    // Recursive call for each subdirectory.
                     WalkDirectoryTree(dirInfo);
                 }
             }


### PR DESCRIPTION
## Summary
- correct a typo in Program.cs comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6849bbc84aec8328b3e31d3acff84eef