### PR TITLE
Fix build warnings

### DIFF
--- a/ImageCrawler/ImageCrawler.csproj
+++ b/ImageCrawler/ImageCrawler.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DupImageLib" Version="1.1.0" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="7.4.3" />
-    <PackageReference Include="MetadataExtractor" Version="2.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
+    <PackageReference Include="DupImageLib" Version="1.2.0" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.6.0" />
+    <PackageReference Include="MetadataExtractor" Version="2.8.1" />
+    <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update all dependencies
- modernize target framework to net8.0

## Testing
- `dotnet build ImageOrganizer.sln`
- `dotnet build ImageOrganizer.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_b_6849bc91fa888328a0e3b75c03470a8c